### PR TITLE
added become parameter to allow privilege escalation with become_user for standalone role

### DIFF
--- a/tasks/secure_installation.yml
+++ b/tasks/secure_installation.yml
@@ -10,6 +10,7 @@
   with_flattened:
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
+  become: true
   when: item.name|d() and item.name
   no_log: True
 
@@ -24,6 +25,7 @@
   with_flattened:
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
+  become: true
   when: item.name|d() and item.name
 
 - name: Revoke all privileges on schema public from PUBLIC
@@ -38,6 +40,7 @@
   with_flattened:
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
+  become: true
   when: item.name|d() and item.name
 
 - name: Grant connect on postgres to PUBLIC
@@ -51,6 +54,7 @@
   with_flattened:
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
+  become: true
   when: item.name|d() and item.name
 
 - name: Revoke temporary on postgres from PUBLIC
@@ -64,5 +68,6 @@
   with_flattened:
     - '{{ postgresql_server__clusters }}'
   become_user: '{{ item.user | d(postgresql_server__user) }}'
+  become: true
   when: item.name|d() and item.name
 


### PR DESCRIPTION
When using it as standalone role I get error:
```
TASK: [debops.postgresql_server | Update default admin password] ************** 
failed: [172.24.10.10] => (item={'name': 'main', 'port': '5432'}) => {"failed": true, "item": {"name": "main", "port": "5432"}}
msg: unable to connect to database: FATAL:  Peer authentication failed for user "postgres"
```

The fix itself is simple, just add **become** parameter to every task that is executed by another user to get escalation.

Actually, I'm a bit frustrated because original role runs without any error when initiated from debops framework. Can't find out why because it doesn't rely on any variable. Could you point why ?