### PR TITLE
Bugfix: ansible_local.core.admin_users not a list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,7 +113,7 @@ postgresql_server__max_connections: '100'
 # as ``postgres`` role with peer authentication. The special ``*postgres*``
 # account name is replaced with username of the cluster system user.
 postgresql_server__admins: '{{ [ "root", "*postgres*" ] +
-                               (ansible_local.core.admin_users
+                               ([ ansible_local.core.admin_users ]
                                 if (ansible_local|d() and ansible_local.core|d() and
                                     ansible_local.core.admin_users|d())
                                 else []) }}'


### PR DESCRIPTION
Even if the name suggests differently, ansible_local.core.admin_users is not a list if set in the debops.core role. Together with applying the role debops.core fixes #8 . Without applying the core role ansible_local.init is not set, but if applying the cole, this error occurs

```
TASK [debops.postgresql_server : debug] ****************************************
fatal: [default]: FAILED! => {"failed": true, "msg": "[{u'map': u'system', u'role': u'*postgres*', u'user': u'{{ postgresql_server__admins }}'}]: {{ [ \"root\", \"*postgres*\" ] + (ansible_local.core.admin_users if (ansible_local|d() and ansible_local.core|d() and ansible_local.core.admin_users|d()) else []) }}: Unexpected templating type error occurred on ({{ [ \"root\", \"*postgres*\" ] + (ansible_local.core.admin_users if (ansible_local|d() and ansible_local.core|d() and ansible_local.core.admin_users|d()) else []) }}): can only concatenate list (not \"AnsibleUnsafeText\") to list"}
```
