### PR TITLE
Fix postgres version requirements in main template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.postgresql_server master: https://github.com/debops/ansible-postgresql_server/compare/v0.3.3...master
 
+Fixed
+~~~~~
+
+- Fix a wrong postgres version check on the main postgresql.conf template.
+
 
 `debops.postgresql_server v0.3.3`_ - 2016-12-14
 -----------------------------------------------

--- a/templates/etc/postgresql/postgresql.conf.j2
+++ b/templates/etc/postgresql/postgresql.conf.j2
@@ -105,7 +105,6 @@ max_stack_depth = {{ item.max_stack_depth | d('2MB') }}
 huge_pages = {{ item.huge_pages | d('try') }}
 autovacuum_work_mem = {{ item.autovacuum_work_mem | d('-1') }}
 {% endif %}
-max_stack_depth = {{ item.max_stack_depth | d('2MB') }}
 
 {% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
 {% if postgresql_server__register_shm|d() and postgresql_server__register_shm.stdout %}

--- a/templates/etc/postgresql/postgresql.conf.j2
+++ b/templates/etc/postgresql/postgresql.conf.j2
@@ -43,7 +43,7 @@ authentication_timeout = {{ item.authentication_timeout | d('1min') }}
 
 ssl = {{ item.ssl | d(postgresql_server__pki | bool | lower) }}
 ssl_ciphers = '{{ item.ssl_ciphers | d(postgresql_server__ssl_ciphers) }}'
-{% if ((item.version | d(postgresql_server__version)) | version_compare('9.1','>')) %}
+{% if ((item.version | d(postgresql_server__version)) | version_compare('9.3','>')) %}
 ssl_prefer_server_ciphers = {{ item.ssl_prefer_server_ciphers | d('on') }}
 
 ssl_ecdh_curve = {{ item.ssl_ecdh_curve | d('prime256v1') }}
@@ -107,7 +107,7 @@ autovacuum_work_mem = {{ item.autovacuum_work_mem | d('-1') }}
 {% endif %}
 max_stack_depth = {{ item.max_stack_depth | d('2MB') }}
 
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
 {% if postgresql_server__register_shm|d() and postgresql_server__register_shm.stdout %}
 dynamic_shared_memory_type = {{ item.dynamic_shared_memory_type | d('posix') }}
 {% else %}
@@ -164,7 +164,7 @@ wal_sync_method = {{ item.wal_sync_method | d('fsync') }}
 full_page_writes = {{ item.full_page_writes | d('on') }}
 wal_buffers = {{ item.wal_buffers | d('-1') }}
 wal_writer_delay = {{ item.wal_writer_delay | d('200ms') }}
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
 wal_log_hints = {{ item.wal_log_hints | d('off') }}
 {% endif %}
 
@@ -212,9 +212,10 @@ max_wal_senders = {{ item.max_wal_senders | d('0') }}
 wal_keep_segments = {{ item.wal_keep_segments | d('0') }}
 {% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
 wal_sender_timeout = {{ item.wal_sender_timeout | d('60s') }}
+{% endif %}
+{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
 max_replication_slots = {{ item.max_replication_slots | d('0') }}
 {% endif %}
-
 
 # - Master Server -
 
@@ -441,7 +442,7 @@ default_text_search_config = '{{ item.default_text_search_config | d("pg_catalog
 
 dynamic_library_path = '{{ item.dynamic_library_path | d("$libdir") }}'
 local_preload_libraries = '{{ item.local_preload_libraries | d("") }}'
-{% if (item.version | d(postgresql_server__version)) | version_compare('9.1','>') %}
+{% if (item.version | d(postgresql_server__version)) | version_compare('9.3','>') %}
 session_preload_libraries = '{{ item.session_preload_libraries | d("") }}'
 {% endif %}
 


### PR DESCRIPTION
The following settings were introduced in Postgres 9.4 and not in 9.2, this commit fixes the wrong version check.

```
ssl_prefer_server_ciphers
ssl_ecdh_curve
dynamic_shared_memory_type
wal_log_hints
max_replication_slots
session_preload_libraries
```